### PR TITLE
chore: cleans up semantic-release stuff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hover-video-player",
-  "version": "6.6.1",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2864,35 +2864,35 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
-      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.1.tgz",
+      "integrity": "sha512-NB81O5h39KfHYGtgfWr2booRxp2bWOJoqbWwbyUg2hw6h35ArWYlAST5B3XwAkbdcx13yt84hFXyFP5X0QToWA==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0"
+        "@octokit/types": "^4.0.1"
       }
     },
     "@octokit/core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-uvzmkemQrBgD8xuGbjhxzJN1darJk9L2cS+M99cHrDG2jlSVpxNJVhoV86cXdYBqdHCc9Z995uLCczaaHIYA6Q==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-2.5.3.tgz",
+      "integrity": "sha512-23AHK9xBW0v79Ck8h5U+5iA4MW7aosqv+Yr6uZXolVGNzzHwryNH5wM386/6+etiKUTwLFZTqyMU9oQpIBZcFA==",
       "dev": true,
       "requires": {
         "@octokit/auth-token": "^2.4.0",
         "@octokit/graphql": "^4.3.1",
         "@octokit/request": "^5.4.0",
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^4.0.1",
         "before-after-hook": "^2.1.0",
         "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/endpoint": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.1.tgz",
-      "integrity": "sha512-pOPHaSz57SFT/m3R5P8MUu4wLPszokn5pXcB/pzavLTQf2jbU+6iayTvzaY6/BiotuRS0qyEUkx3QglT4U958A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.2.tgz",
+      "integrity": "sha512-xs1mmCEZ2y4shXCpFjNq3UbmNR+bLzxtZim2L0zfEtj9R6O6kc4qLDvYw66hvO6lUsYzPTM5hMkltbuNAbRAcQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.11.1",
+        "@octokit/types": "^4.0.1",
         "is-plain-object": "^3.0.0",
         "universal-user-agent": "^5.0.0"
       },
@@ -2915,23 +2915,23 @@
       }
     },
     "@octokit/graphql": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.4.0.tgz",
-      "integrity": "sha512-Du3hAaSROQ8EatmYoSAJjzAz3t79t9Opj/WY1zUgxVUGfIKn0AEjg+hlOLscF6fv6i/4y/CeUvsWgIfwMkTccw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.0.tgz",
+      "integrity": "sha512-StJWfn0M1QfhL3NKBz31e1TdDNZrHLLS57J2hin92SIfzlOVBuUaRkp31AGkGOAFOAVtyEX6ZiZcsjcJDjeb5g==",
       "dev": true,
       "requires": {
         "@octokit/request": "^5.3.0",
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^4.0.1",
         "universal-user-agent": "^5.0.0"
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.0.tgz",
-      "integrity": "sha512-KoNxC3PLNar8UJwR+1VMQOw2IoOrrFdo5YOiDKnBhpVbKpw+zkBKNMNKwM44UWL25Vkn0Sl3nYIEGKY+gW5ebw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.2.1.tgz",
+      "integrity": "sha512-/tHpIF2XpN40AyhIq295YRjb4g7Q5eKob0qM3thYJ0Z+CgmNsWKM/fWse/SUR8+LdprP1O4ZzSKQE+71TCwK+w==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.12.1"
+        "@octokit/types": "^4.0.1"
       }
     },
     "@octokit/plugin-request-log": {
@@ -2941,35 +2941,24 @@
       "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.12.2.tgz",
-      "integrity": "sha512-QUfJ6nriHpwTxf8As99kEyDQV4AGQvypsM8Xyx5rsWi6JY7rzjOkZrleRrFq0aiNcQo7acM4bwaXq462OKTJ9w==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-3.17.0.tgz",
+      "integrity": "sha512-NFV3vq7GgoO2TrkyBRUOwflkfTYkFKS0tLAPym7RNpkwLCttqShaEGjthOsPEEL+7LFcYv3mU24+F2yVd3npmg==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^4.0.0",
+        "@octokit/types": "^4.1.6",
         "deprecation": "^2.3.1"
-      },
-      "dependencies": {
-        "@octokit/types": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.0.1.tgz",
-          "integrity": "sha512-Ho6h7w2h9y8RRE8r656hIj1oiSbwbIHJGF5r9G5FOwS2VdDPq8QLGvsG4x6pKHpvyGK7j+43sAc2cJKMiFoIJw==",
-          "dev": true,
-          "requires": {
-            "@types/node": ">= 8"
-          }
-        }
       }
     },
     "@octokit/request": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.2.tgz",
-      "integrity": "sha512-zKdnGuQ2TQ2vFk9VU8awFT4+EYf92Z/v3OlzRaSh4RIP0H6cvW1BFPXq4XYvNez+TPQjqN+0uSkCYnMFFhcFrw==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.4.tgz",
+      "integrity": "sha512-vqv1lz41c6VTxUvF9nM+a6U+vvP3vGk7drDpr0DVQg4zyqlOiKVrY17DLD6de5okj+YLHKcoqaUZTBtlNZ1BtQ==",
       "dev": true,
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.0.0",
-        "@octokit/types": "^2.11.1",
+        "@octokit/types": "^4.0.1",
         "deprecation": "^2.0.0",
         "is-plain-object": "^3.0.0",
         "node-fetch": "^2.3.0",
@@ -2995,32 +2984,32 @@
       }
     },
     "@octokit/request-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
-      "integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.1.tgz",
+      "integrity": "sha512-5lqBDJ9/TOehK82VvomQ6zFiZjPeSom8fLkFVLuYL3sKiIb5RB8iN/lenLkY7oBmyQcGP7FBMGiIZTO8jufaRQ==",
       "dev": true,
       "requires": {
-        "@octokit/types": "^2.0.0",
+        "@octokit/types": "^4.0.1",
         "deprecation": "^2.0.0",
         "once": "^1.4.0"
       }
     },
     "@octokit/rest": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.9.2.tgz",
-      "integrity": "sha512-UXxiE0HhGQAPB3WDHTEu7lYMHH2uRcs/9f26XyHpGGiiXht8hgHWEk6fA7WglwwEvnj8V7mkJOgIntnij132UA==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-17.11.0.tgz",
+      "integrity": "sha512-WqXmm37uCGP1NxYxSc27hd5pYNLdksuUsjR8vaNS8fCy6kyxZFy+Dbh/AzqKGj2mOdbnt7dILoGHfzsA4IIm4A==",
       "dev": true,
       "requires": {
         "@octokit/core": "^2.4.3",
         "@octokit/plugin-paginate-rest": "^2.2.0",
         "@octokit/plugin-request-log": "^1.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^3.12.2"
+        "@octokit/plugin-rest-endpoint-methods": "3.17.0"
       }
     },
     "@octokit/types": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
-      "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-4.1.9.tgz",
+      "integrity": "sha512-hinM/BA2c1vebN2HSR3JtVdYtrSbmvn/doUBZXXuQuh/9o60hYwitQQAGTpJu+k6pjtjURskDHQxUFvqLvYCeA==",
       "dev": true,
       "requires": {
         "@types/node": ">= 8"
@@ -3047,48 +3036,6 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
-      }
-    },
-    "@semantic-release/changelog": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-5.0.1.tgz",
-      "integrity": "sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "^2.1.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^9.0.0",
-        "lodash": "^4.17.4"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^1.0.0"
-          }
-        },
-        "jsonfile": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^1.0.0"
-          }
-        },
-        "universalify": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
-          "dev": true
-        }
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -3129,110 +3076,10 @@
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
     },
-    "@semantic-release/git": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-9.0.0.tgz",
-      "integrity": "sha512-AZ4Zha5NAPAciIJH3ipzw/WU9qLAn8ENaoVAhD6srRPxTpTzuV3NhNh14rcAo8Paj9dO+5u4rTKcpetOBluYVw==",
-      "dev": true,
-      "requires": {
-        "@semantic-release/error": "^2.1.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "execa": "^4.0.0",
-        "lodash": "^4.17.4",
-        "micromatch": "^4.0.0",
-        "p-reduce": "^2.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
-          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          }
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "execa": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
-          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "npm-run-path": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
-        },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        }
-      }
-    },
     "@semantic-release/github": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.6.tgz",
-      "integrity": "sha512-70fUj+t98AWRgeOG0j2kdguvaVyysOZRUmXykZBwkktSDm1UZ6YfelYFPuM9OJbKPuNjKsCsRXl5/wukDUg8PA==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-7.0.7.tgz",
+      "integrity": "sha512-Sai2UucYQ+5rJzKVEVJ4eiZNDdoo0/CzfpValBdeU5h97uJE7t4CoBTmUWkiXlPOx46CSw1+JhI+PHC1PUxVZw==",
       "dev": true,
       "requires": {
         "@octokit/rest": "^17.0.0",
@@ -3253,25 +3100,10 @@
         "url-join": "^4.0.0"
       },
       "dependencies": {
-        "array-union": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-          "dev": true
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
         "fs-extra": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
-          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
           "dev": true,
           "requires": {
             "at-least-node": "^1.0.0",
@@ -3279,26 +3111,6 @@
             "jsonfile": "^6.0.1",
             "universalify": "^1.0.0"
           }
-        },
-        "globby": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-          "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
-            "slash": "^3.0.0"
-          }
-        },
-        "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-          "dev": true
         },
         "jsonfile": {
           "version": "6.0.1",
@@ -15053,7 +14865,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
           "dev": true,
           "requires": {
             "jsonparse": "^1.2.0",
@@ -15062,12 +14875,14 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true
         },
         "agent-base": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "dev": true,
           "requires": {
             "es6-promisify": "^5.0.0"
@@ -15075,7 +14890,8 @@
         },
         "agentkeepalive": {
           "version": "3.5.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "dev": true,
           "requires": {
             "humanize-ms": "^1.2.1"
@@ -15083,7 +14899,8 @@
         },
         "ajv": {
           "version": "5.5.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "dev": true,
           "requires": {
             "co": "^4.6.0",
@@ -15094,7 +14911,8 @@
         },
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0"
@@ -15102,12 +14920,14 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
@@ -15115,27 +14935,32 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
           "dev": true
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
           "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -15144,7 +14969,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -15158,7 +14984,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -15168,12 +14995,14 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
           "dev": true
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "dev": true,
           "requires": {
             "safer-buffer": "~2.1.0"
@@ -15181,32 +15010,38 @@
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
           "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -15215,7 +15050,8 @@
         },
         "bin-links": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-/eaLaTu7G7/o7PV04QPy1HRT65zf+1tFkPGv0sPTV0tRwufooYBQO3zrcyGgm+ja+ZtBf2GEuKjDRJ2pPG+yqA==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -15228,12 +15064,14 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "dev": true,
           "requires": {
             "ansi-align": "^2.0.0",
@@ -15247,7 +15085,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -15256,27 +15095,32 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
           "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
           "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
           "dev": true
         },
         "byte-size": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
           "dev": true
         },
         "cacache": {
           "version": "12.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.5",
@@ -15298,27 +15142,32 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ==",
           "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -15328,17 +15177,20 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "dev": true
         },
         "cidr-regex": {
           "version": "2.0.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
           "dev": true,
           "requires": {
             "ip-regex": "^2.1.0"
@@ -15346,12 +15198,14 @@
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "dev": true,
           "requires": {
             "string-width": "^2.0.0",
@@ -15360,7 +15214,8 @@
         },
         "cli-table3": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
           "dev": true,
           "requires": {
             "colors": "^1.1.2",
@@ -15370,7 +15225,8 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1",
@@ -15380,12 +15236,14 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -15395,12 +15253,14 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         },
         "cmd-shim": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -15409,17 +15269,20 @@
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "dev": true,
           "requires": {
             "color-name": "^1.1.1"
@@ -15427,18 +15290,21 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "colors": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "dev": true,
           "requires": {
             "strip-ansi": "^3.0.0",
@@ -15447,7 +15313,8 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
@@ -15455,12 +15322,14 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",
@@ -15471,7 +15340,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -15485,7 +15355,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -15495,7 +15366,8 @@
         },
         "config-chain": {
           "version": "1.1.12",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
           "dev": true,
           "requires": {
             "ini": "^1.3.4",
@@ -15504,7 +15376,8 @@
         },
         "configstore": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
           "dev": true,
           "requires": {
             "dot-prop": "^4.1.0",
@@ -15517,12 +15390,14 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -15535,24 +15410,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "dev": true,
           "requires": {
             "capture-stack-trace": "^1.0.0"
@@ -15560,7 +15439,8 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -15570,7 +15450,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "dev": true,
               "requires": {
                 "pseudomap": "^1.0.2",
@@ -15579,24 +15460,28 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
               "dev": true
             }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
           "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -15604,7 +15489,8 @@
         },
         "debug": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -15612,34 +15498,40 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
           "dev": true
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true
         },
         "defaults": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "dev": true,
           "requires": {
             "clone": "^1.0.2"
@@ -15647,7 +15539,8 @@
         },
         "define-properties": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "dev": true,
           "requires": {
             "object-keys": "^1.0.12"
@@ -15655,27 +15548,32 @@
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
           "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "dev": true,
           "requires": {
             "asap": "^2.0.0",
@@ -15684,7 +15582,8 @@
         },
         "dot-prop": {
           "version": "4.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
             "is-obj": "^1.0.0"
@@ -15692,17 +15591,20 @@
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
           "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
           "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.0.0",
@@ -15713,7 +15615,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -15727,7 +15630,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -15737,7 +15641,8 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -15747,12 +15652,14 @@
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
           "dev": true
         },
         "encoding": {
           "version": "0.1.12",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "dev": true,
           "requires": {
             "iconv-lite": "~0.4.13"
@@ -15760,7 +15667,8 @@
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "dev": true,
           "requires": {
             "once": "^1.4.0"
@@ -15768,17 +15676,20 @@
         },
         "env-paths": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
           "dev": true
         },
         "err-code": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
           "dev": true
         },
         "errno": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "dev": true,
           "requires": {
             "prr": "~1.0.1"
@@ -15786,7 +15697,8 @@
         },
         "es-abstract": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.1.1",
@@ -15798,7 +15710,8 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "dev": true,
           "requires": {
             "is-callable": "^1.1.4",
@@ -15808,12 +15721,14 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
           "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "dev": true,
           "requires": {
             "es6-promise": "^4.0.3"
@@ -15821,12 +15736,14 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -15840,44 +15757,52 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
           "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
           "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
           "dev": true
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
           "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
           "dev": true
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "^2.0.0"
@@ -15885,7 +15810,8 @@
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -15894,7 +15820,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -15908,7 +15835,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -15918,12 +15846,14 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true
         },
         "form-data": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
@@ -15933,7 +15863,8 @@
         },
         "from2": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "dev": true,
           "requires": {
             "inherits": "^2.0.1",
@@ -15942,7 +15873,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -15956,7 +15888,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -15966,7 +15899,8 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "dev": true,
           "requires": {
             "minipass": "^2.6.0"
@@ -15974,7 +15908,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -15985,7 +15920,8 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -15995,7 +15931,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -16006,12 +15943,14 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -16025,7 +15964,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -16035,17 +15975,20 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "dev": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -16060,12 +16003,14 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -16077,12 +16022,14 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==",
           "dev": true
         },
         "gentle-fs": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3k2CgAmPxuz7S6nKK+AqFE2AdM1QuwqKLPKzIET3VRwK++3q96MsNFobScDjlCrq97ZJ8y5R725MOlm6ffUCjg==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.2",
@@ -16100,24 +16047,28 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
               "dev": true
             }
           }
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
           "dev": true
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"
@@ -16125,7 +16076,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
@@ -16133,7 +16085,8 @@
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -16146,7 +16099,8 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
             "ini": "^1.3.4"
@@ -16154,7 +16108,8 @@
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
             "create-error-class": "^3.0.0",
@@ -16172,24 +16127,28 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
               "dev": true
             }
           }
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
           "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
           "dev": true
         },
         "har-validator": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
           "dev": true,
           "requires": {
             "ajv": "^5.3.0",
@@ -16198,7 +16157,8 @@
         },
         "has": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
             "function-bind": "^1.1.1"
@@ -16206,32 +16166,38 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "has-symbols": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
           "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
           "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
           "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "dev": true,
           "requires": {
             "agent-base": "4",
@@ -16240,7 +16206,8 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -16250,7 +16217,8 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "dev": true,
           "requires": {
             "agent-base": "^4.3.0",
@@ -16259,7 +16227,8 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "dev": true,
           "requires": {
             "ms": "^2.0.0"
@@ -16267,7 +16236,8 @@
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -16275,12 +16245,14 @@
         },
         "iferr": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
           "dev": true
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "dev": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -16288,22 +16260,26 @@
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -16312,17 +16288,20 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -16337,27 +16316,32 @@
         },
         "invert-kv": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
           "dev": true
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
           "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
           "dev": true
         },
         "is-callable": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
           "dev": true
         },
         "is-ci": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "dev": true,
           "requires": {
             "ci-info": "^1.5.0"
@@ -16365,14 +16349,16 @@
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
               "dev": true
             }
           }
         },
         "is-cidr": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
           "dev": true,
           "requires": {
             "cidr-regex": "^2.0.10"
@@ -16380,12 +16366,14 @@
         },
         "is-date-object": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -16393,7 +16381,8 @@
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
             "global-dirs": "^0.1.0",
@@ -16402,17 +16391,20 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
             "path-is-inside": "^1.0.1"
@@ -16420,12 +16412,14 @@
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
           "dev": true
         },
         "is-regex": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "dev": true,
           "requires": {
             "has": "^1.0.1"
@@ -16433,17 +16427,20 @@
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-symbol": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "dev": true,
           "requires": {
             "has-symbols": "^1.0.0"
@@ -16451,58 +16448,69 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
           "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
           "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
           "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
@@ -16513,7 +16521,8 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
             "package-json": "^4.0.0"
@@ -16521,12 +16530,14 @@
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
           "dev": true
         },
         "lcid": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
             "invert-kv": "^2.0.0"
@@ -16534,7 +16545,8 @@
         },
         "libcipm": {
           "version": "4.0.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fTq33otU3PNXxxCTCYCYe7V96o59v/o7bvtspmbORXpgFk+wcWrGf5x6tBgui5gCed/45/wtPomBsZBYm5KbIw==",
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -16556,7 +16568,8 @@
         },
         "libnpm": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
           "dev": true,
           "requires": {
             "bin-links": "^1.1.2",
@@ -16583,7 +16596,8 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -16594,7 +16608,8 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -16604,7 +16619,8 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "dev": true,
               "requires": {
                 "locate-path": "^3.0.0"
@@ -16612,7 +16628,8 @@
             },
             "locate-path": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "dev": true,
               "requires": {
                 "p-locate": "^3.0.0",
@@ -16621,7 +16638,8 @@
             },
             "p-limit": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
               "dev": true,
               "requires": {
                 "p-try": "^2.0.0"
@@ -16629,7 +16647,8 @@
             },
             "p-locate": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "dev": true,
               "requires": {
                 "p-limit": "^2.0.0"
@@ -16637,14 +16656,16 @@
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
               "dev": true
             }
           }
         },
         "libnpmhook": {
           "version": "5.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -16655,7 +16676,8 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -16666,7 +16688,8 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -16682,7 +16705,8 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -16692,7 +16716,8 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
@@ -16703,7 +16728,8 @@
         },
         "libnpx": {
           "version": "10.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ujaYToga1SAX5r7FU5ShMFi88CWpY75meNZtr6RtEyv4l2ZK3+Wgvxq2IqlwWBiDZOqhumdeiocPS1aKrCMe3A==",
           "dev": true,
           "requires": {
             "dotenv": "^5.0.1",
@@ -16718,7 +16744,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "^2.0.0",
@@ -16727,7 +16754,8 @@
         },
         "lock-verify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
           "dev": true,
           "requires": {
             "npm-package-arg": "^6.1.0",
@@ -16736,7 +16764,8 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "dev": true,
           "requires": {
             "signal-exit": "^3.0.2"
@@ -16744,12 +16773,14 @@
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
           "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "dev": true,
           "requires": {
             "lodash._createset": "~4.0.0",
@@ -16758,17 +16789,20 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
           "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
           "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "dev": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
@@ -16776,52 +16810,62 @@
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
           "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
           "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
           "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
           "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
           "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
           "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
           "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
           "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
           "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
             "yallist": "^3.0.2"
@@ -16829,7 +16873,8 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "dev": true,
           "requires": {
             "pify": "^3.0.0"
@@ -16837,7 +16882,8 @@
         },
         "make-fetch-happen": {
           "version": "5.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
           "dev": true,
           "requires": {
             "agentkeepalive": "^3.4.1",
@@ -16855,7 +16901,8 @@
         },
         "map-age-cleaner": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
           "dev": true,
           "requires": {
             "p-defer": "^1.0.0"
@@ -16863,12 +16910,14 @@
         },
         "meant": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
           "dev": true
         },
         "mem": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -16878,19 +16927,22 @@
           "dependencies": {
             "mimic-fn": {
               "version": "2.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
               "dev": true
             }
           }
         },
         "mime-db": {
           "version": "1.35.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "dev": true,
           "requires": {
             "mime-db": "~1.35.0"
@@ -16898,7 +16950,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -16906,7 +16959,8 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "dev": true,
           "requires": {
             "minipass": "^2.9.0"
@@ -16914,7 +16968,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -16925,7 +16980,8 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "dev": true,
           "requires": {
             "concat-stream": "^1.5.0",
@@ -16942,7 +16998,8 @@
         },
         "mkdirp": {
           "version": "0.5.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -16950,14 +17007,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1",
@@ -16970,29 +17029,34 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
         },
         "nice-try": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
           "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "dev": true,
           "requires": {
             "encoding": "^0.1.11",
@@ -17002,7 +17066,8 @@
         },
         "node-gyp": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
@@ -17020,7 +17085,8 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "dev": true,
           "requires": {
             "abbrev": "1",
@@ -17029,7 +17095,8 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -17040,7 +17107,8 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "dev": true,
               "requires": {
                 "path-parse": "^1.0.6"
@@ -17050,7 +17118,8 @@
         },
         "npm-audit-report": {
           "version": "1.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-abeqS5ONyXNaZJPGAf6TOUMNdSe1Y6cpc9MLBRn+CuUoYbfdca6AxOyXVlfIv9OgKX+cacblbG5w7A6ccwoTPw==",
           "dev": true,
           "requires": {
             "cli-table3": "^0.5.0",
@@ -17059,7 +17128,8 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "dev": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
@@ -17067,12 +17137,14 @@
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
           "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
           "dev": true,
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
@@ -17080,7 +17152,8 @@
         },
         "npm-lifecycle": {
           "version": "3.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
           "dev": true,
           "requires": {
             "byline": "^5.0.0",
@@ -17095,17 +17168,20 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
           "dev": true
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "dev": true
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.7.1",
@@ -17116,7 +17192,8 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "dev": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -17126,7 +17203,8 @@
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -17136,7 +17214,8 @@
         },
         "npm-profile": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "dev": true,
           "requires": {
             "aproba": "^1.1.2 || 2",
@@ -17146,7 +17225,8 @@
         },
         "npm-registry-fetch": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.4.tgz",
+          "integrity": "sha512-6jb34hX/iYNQebqWUHtU8YF6Cjb1H6ouTFPClYsyiW6lpFkljTpdeftm53rRojtja1rKAvKNIIiTS5Sjpw4wsA==",
           "dev": true,
           "requires": {
             "JSONStream": "^1.3.4",
@@ -17160,14 +17240,16 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -17175,12 +17257,14 @@
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
           "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -17191,27 +17275,32 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object-keys": {
           "version": "1.0.12",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
           "dev": true
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
           "dev": true,
           "requires": {
             "define-properties": "^1.1.2",
@@ -17220,7 +17309,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -17228,17 +17318,20 @@
         },
         "opener": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
           "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
           "dev": true,
           "requires": {
             "execa": "^1.0.0",
@@ -17248,7 +17341,8 @@
           "dependencies": {
             "cross-spawn": {
               "version": "6.0.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "dev": true,
               "requires": {
                 "nice-try": "^1.0.4",
@@ -17260,7 +17354,8 @@
             },
             "execa": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
               "dev": true,
               "requires": {
                 "cross-spawn": "^6.0.0",
@@ -17276,12 +17371,14 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -17290,22 +17387,26 @@
         },
         "p-defer": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
           "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-is-promise": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
           "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -17313,7 +17414,8 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "^1.1.0"
@@ -17321,12 +17423,14 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
             "got": "^6.7.1",
@@ -17337,7 +17441,8 @@
         },
         "pacote": {
           "version": "9.5.12",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
           "dev": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -17374,7 +17479,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -17385,7 +17491,8 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "dev": true,
           "requires": {
             "cyclist": "~0.2.2",
@@ -17395,7 +17502,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -17409,7 +17517,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -17419,57 +17528,68 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
           "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
           "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "dev": true,
           "requires": {
             "err-code": "^1.0.0",
@@ -17478,14 +17598,16 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
               "dev": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "dev": true,
           "requires": {
             "read": "1"
@@ -17493,12 +17615,14 @@
         },
         "proto-list": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
           "dev": true
         },
         "protoduck": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "dev": true,
           "requires": {
             "genfun": "^5.0.0"
@@ -17506,22 +17630,26 @@
         },
         "prr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
           "dev": true
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -17530,7 +17658,8 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "dev": true,
           "requires": {
             "duplexify": "^3.6.0",
@@ -17540,7 +17669,8 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "dev": true,
               "requires": {
                 "end-of-stream": "^1.1.0",
@@ -17551,22 +17681,26 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
           "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         },
         "query-string": {
           "version": "6.8.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "dev": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
@@ -17576,12 +17710,14 @@
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
           "dev": true
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "requires": {
             "deep-extend": "^0.6.0",
@@ -17592,14 +17728,16 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
               "dev": true
             }
           }
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "dev": true,
           "requires": {
             "mute-stream": "~0.0.4"
@@ -17607,7 +17745,8 @@
         },
         "read-cmd-shim": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -17615,7 +17754,8 @@
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -17629,7 +17769,8 @@
         },
         "read-package-json": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
           "dev": true,
           "requires": {
             "glob": "^7.1.1",
@@ -17641,7 +17782,8 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
           "dev": true,
           "requires": {
             "read-package-json": "^2.0.0",
@@ -17651,7 +17793,8 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -17661,7 +17804,8 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "dev": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -17672,7 +17816,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "dev": true,
           "requires": {
             "rc": "^1.1.6",
@@ -17681,7 +17826,8 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
             "rc": "^1.0.1"
@@ -17689,7 +17835,8 @@
         },
         "request": {
           "version": "2.88.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "dev": true,
           "requires": {
             "aws-sign2": "~0.7.0",
@@ -17716,27 +17863,32 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
           "dev": true
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -17744,7 +17896,8 @@
         },
         "run-queue": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "dev": true,
           "requires": {
             "aproba": "^1.1.1"
@@ -17752,29 +17905,34 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
               "dev": true
             }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
             "semver": "^5.0.3"
@@ -17782,12 +17940,14 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "sha": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2"
@@ -17795,7 +17955,8 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -17803,27 +17964,32 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
           "dev": true
         },
         "socks": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
           "dev": true,
           "requires": {
             "ip": "1.1.5",
@@ -17832,7 +17998,8 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
           "dev": true,
           "requires": {
             "agent-base": "~4.2.1",
@@ -17841,7 +18008,8 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
               "dev": true,
               "requires": {
                 "es6-promisify": "^5.0.0"
@@ -17851,12 +18019,14 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
           "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "dev": true,
           "requires": {
             "from2": "^1.3.0",
@@ -17865,7 +18035,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "dev": true,
               "requires": {
                 "inherits": "~2.0.1",
@@ -17874,12 +18045,14 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
               "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -17890,14 +18063,16 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
               "dev": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -17906,12 +18081,14 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -17920,17 +18097,20 @@
         },
         "spdx-license-ids": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
           "dev": true
         },
         "split-on-first": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
           "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "dev": true,
           "requires": {
             "asn1": "~0.2.3",
@@ -17946,7 +18126,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1"
@@ -17954,7 +18135,8 @@
         },
         "stream-each": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -17963,7 +18145,8 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
@@ -17972,7 +18155,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -17986,7 +18170,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -17996,17 +18181,20 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
           "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -18015,17 +18203,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -18035,7 +18226,8 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.2.0"
@@ -18043,19 +18235,22 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
               "dev": true
             }
           }
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -18063,17 +18258,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -18081,7 +18279,8 @@
         },
         "tar": {
           "version": "4.4.13",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "dev": true,
           "requires": {
             "chownr": "^1.1.1",
@@ -18095,7 +18294,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
@@ -18106,7 +18306,8 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
             "execa": "^0.7.0"
@@ -18114,17 +18315,20 @@
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
           "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
           "dev": true
         },
         "through2": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "dev": true,
           "requires": {
             "readable-stream": "^2.1.5",
@@ -18133,7 +18337,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
@@ -18147,7 +18352,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
@@ -18157,17 +18363,20 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
           "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
             "psl": "^1.1.24",
@@ -18176,7 +18385,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
@@ -18184,28 +18394,33 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
           "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
           "dev": true
         },
         "unique-filename": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "dev": true,
           "requires": {
             "unique-slug": "^2.0.0"
@@ -18213,7 +18428,8 @@
         },
         "unique-slug": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -18221,7 +18437,8 @@
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
             "crypto-random-string": "^1.0.0"
@@ -18229,17 +18446,20 @@
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
           "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "dev": true,
           "requires": {
             "boxen": "^1.2.1",
@@ -18256,7 +18476,8 @@
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
             "prepend-http": "^1.0.1"
@@ -18264,17 +18485,20 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
           "dev": true
         },
         "util-promisify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
           "dev": true,
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3"
@@ -18282,12 +18506,14 @@
         },
         "uuid": {
           "version": "3.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -18296,7 +18522,8 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "dev": true,
           "requires": {
             "builtins": "^1.0.3"
@@ -18304,7 +18531,8 @@
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0",
@@ -18314,7 +18542,8 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "dev": true,
           "requires": {
             "defaults": "^1.0.3"
@@ -18322,7 +18551,8 @@
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -18330,12 +18560,14 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -18343,7 +18575,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -18355,7 +18588,8 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "dev": true,
           "requires": {
             "string-width": "^2.1.1"
@@ -18363,7 +18597,8 @@
         },
         "worker-farm": {
           "version": "1.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "dev": true,
           "requires": {
             "errno": "~0.1.7"
@@ -18371,7 +18606,8 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
@@ -18380,7 +18616,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -18392,12 +18629,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -18407,27 +18646,32 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
           "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         },
         "yargs": {
           "version": "11.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-PRU7gJrJaXv3q3yQZ/+/X6KBswZiaQ+zOmdprZcouPYtQgvNU35i+68M4b1ZHLZtYFT5QObFLV+ZkmJYcwKdiw==",
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
@@ -18446,14 +18690,16 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
               "dev": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
             "camelcase": "^4.1.0"
@@ -25695,9 +25941,9 @@
       }
     },
     "windows-release": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.0.tgz",
-      "integrity": "sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
+      "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hover-video-player",
-  "version": "6.6.1",
+  "version": "0.0.0-development",
   "description": "React component which manages playing a video when the user hovers over it and pausing when they stop.",
   "main": "es/index.js",
   "files": [
@@ -25,8 +25,10 @@
     "@babel/preset-react": "^7.9.4",
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
-    "@semantic-release/changelog": "^5.0.1",
-    "@semantic-release/git": "^9.0.0",
+    "@semantic-release/commit-analyzer": "^8.0.1",
+    "@semantic-release/github": "^7.0.7",
+    "@semantic-release/npm": "^7.0.5",
+    "@semantic-release/release-notes-generator": "^9.0.1",
     "@testing-library/jest-dom": "^5.3.0",
     "@testing-library/react": "^10.0.2",
     "babel-eslint": "^10.1.0",
@@ -119,17 +121,7 @@
       ],
       "@semantic-release/release-notes-generator",
       "@semantic-release/npm",
-      [
-        "@semantic-release/git",
-        {
-          "assets": [
-            "package.json",
-            "package-lock.json",
-            "CHANGELOG.md"
-          ],
-          "message": "chore(release): ${nextRelease.version} [skip ci]nn${nextRelease.notes}"
-        }
-      ]
+      "@semantic-release/github"
     ]
   }
 }


### PR DESCRIPTION
Reverts back to using @semantic-release/github plugin over /git because the github
releases were all messed up and having an updated version number in your development
package.json file isn't worth it