### PR TITLE
Add smoke test for release build version of component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - lts/*
   - 10
-  - 8
 
 cache:
   directories:
@@ -20,6 +19,8 @@ script:
   - commitlint-travis
   - npm test
   - codecov
+  # Run tests against a built release-ready version of the component
+  - npm run test:release
 
 jobs:
   include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,11 @@
 
 Tests are written using [jest](https://github.com/facebook/jest) and [react-testing-library](https://github.com/testing-library/react-testing-library).
 
-- `npm run test` will run all tests once
+- `npm run test` will run all tests once.
 
 - `npm run test:watch` will continually re-run tests as you make changes.
+
+- `npm run test:release` will perform a webpack build (`npm run build`) and then run all tests on the resulting release-ready version of the component for smoke testing purposes. Note that this is much slower and does not perform coverage testing, so you will almost always want to stick with `npm run test`.
 
  **100% code coverage for tests is required**. If you make a change, you must add a test accordingly.
 

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -15,8 +15,4 @@ module.exports = {
       patterns: [{ from: './README.md' }],
     },
   },
-  babel: {
-    // Plugin strips data-testid attribute from elements in build since they're only needed for tests
-    plugins: 'babel-plugin-jsx-remove-data-test-id',
-  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4696,12 +4696,6 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
-    "babel-plugin-jsx-remove-data-test-id": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-remove-data-test-id/-/babel-plugin-jsx-remove-data-test-id-2.1.3.tgz",
-      "integrity": "sha512-FTpcmzr3avLVStllCT4BceTTZNEb+1mJVtLpsicvXDqjojEkyrga1GGOxWj768Ra3tev6KWgNOhZ/Lrucb+MuQ==",
-      "dev": true
-    },
     "babel-plugin-lodash": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "clean": "nwb clean-module && nwb clean-demo",
     "start": "nwb serve-react-demo --webpack.html.template=demo/src/templates/dev-playground.html",
     "start:demo": "nwb serve-react-demo",
-    "test": "jest --config=tests/jest.config.js",
+    "test": "jest --config=tests/jest.dev.config.js",
+    "test:release": "npm run build -- --no-demo && jest --config=tests/jest.prod.config.js",
     "test:watch": "npm run test -- --watch --no-cache",
     "commit": "npx git-cz"
   },
@@ -33,7 +34,6 @@
     "@testing-library/react": "^10.0.2",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.2.6",
-    "babel-plugin-jsx-remove-data-test-id": "^2.1.3",
     "commitizen": "^4.1.2",
     "core-js": "^3.6.5",
     "cz-conventional-changelog": "^3.2.0",

--- a/tests/HoverVideoPlayer.test.js
+++ b/tests/HoverVideoPlayer.test.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import { fireEvent, act, screen, render } from '@testing-library/react';
 
+// This is being mapped in the jest config files so we can alternate between
+// running tests off of the development version (../src) of the component or
+// the built production version (../es)
+// eslint-disable-next-line import/no-unresolved
+import HoverVideoPlayer from 'react-hover-video-player';
+
 import {
   renderHoverVideoPlayer,
   getPlayPromise,
   mockConsoleError,
   addMockedFunctionsToVideoElement,
 } from './utils';
-import HoverVideoPlayer from '../src';
 
 describe('videoSrc prop', () => {
   describe('Handles valid videoSrc prop values correctly', () => {

--- a/tests/jest.base.config.js
+++ b/tests/jest.base.config.js
@@ -1,8 +1,5 @@
 module.exports = {
   rootDir: '../',
-  collectCoverage: true,
-  coverageDirectory: './coverage',
-  coveragePathIgnorePatterns: ['<rootDir>/tests/', '<rootDir>/node_modules/'],
   verbose: true,
   transform: {
     '^.+\\.js$': '<rootDir>/tests/jest.transform.js',

--- a/tests/jest.dev.config.js
+++ b/tests/jest.dev.config.js
@@ -1,0 +1,11 @@
+const baseConfig = require('./jest.base.config');
+
+module.exports = {
+  ...baseConfig,
+  collectCoverage: true,
+  coverageDirectory: './coverage',
+  coveragePathIgnorePatterns: ['<rootDir>/tests/', '<rootDir>/node_modules/'],
+  moduleNameMapper: {
+    'react-hover-video-player': '<rootDir>/src',
+  },
+};

--- a/tests/jest.prod.config.js
+++ b/tests/jest.prod.config.js
@@ -1,0 +1,8 @@
+const baseConfig = require('./jest.base.config');
+
+module.exports = {
+  ...baseConfig,
+  moduleNameMapper: {
+    'react-hover-video-player': '<rootDir>/es',
+  },
+};

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -2,7 +2,11 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
-import HoverVideoPlayer from '../src';
+// This is being mapped in the jest config files so we can alternate between
+// running tests off of the development version (../src) of the component or
+// the built production version (../es)
+// eslint-disable-next-line import/no-unresolved
+import HoverVideoPlayer from 'react-hover-video-player';
 
 const READY_STATES = {
   HAVE_NOTHING: 0,


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Gyanreyer/react-hover-video-player/blob/master/CONTRIBUTING.md) doc.
- [x] I have added/updated unit tests to cover my changes.
- [x] Unit tests pass locally.
- [x] I have added appropriate documentation for my changes.
- [x] I have updated the README to reflect any changes that will affect the component's public API (if applicable).

## Problem

There has previously not been any sort of smoke testing which could catch errant bugs introduced by the webpack-compiled version of the component that we actually release on npm.

## Solution

Adds new `test:release` script which can run all tests against a webpack-compiled version of the component. This is useful for smoke testing purposes to ensure nothing is getting unexpectedly broken in the build process.

Also drops node.js 8 from the travis build environments because it cannot run a release build successfully and is no longer supported anyways.
