### PR TITLE
Fix cannot read pause error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -406,19 +406,6 @@ export default function HoverVideoPlayer({
       // Mark that the player is unmounted so that we won't try to update the component state
       // if the play promise resolves afterward
       mutableVideoState.current.isPlayerUnmounted = true;
-
-      // Clean up the sources for the video to avoid potential memory leaks
-      // It's debatable how necessary this really is but playing it safe never hurts
-      const videoSourceElements = videoElement.getElementsByTagName('source');
-      for (
-        let i = 0, videoSourceCount = videoSourceElements.length;
-        i < videoSourceCount;
-        i += 1
-      ) {
-        videoSourceElements[i].src = '';
-        videoSourceElements[i].removeAttribute('src');
-      }
-      videoElement.load();
     };
   }, []);
   /* ~~~~ END EFFECTS ~~~~ */

--- a/src/index.js
+++ b/src/index.js
@@ -13,35 +13,35 @@ import {
 /**
  * @component HoverVideoPlayer
  *
- * @param {!(string|string[]|VideoSource|VideoSource[])}  videoSrc - Source(s) to use for the video player. Accepts 3 different formats:
+ * @param {(string|string[]|VideoSource|VideoSource[])}  videoSrc - Source(s) to use for the video player. Accepts 3 different formats:
  *                                                                   - **String**: the URL string to use as the video player's src
  *                                                                   - **Object**: an object with attributes:
  *                                                                     - src: The src URL string to use for a video player source
  *                                                                     - type: The media type of the video source, ie 'video/mp4'
  *                                                                   - **Array**: if you would like to provide multiple sources, you can provide an array of URL strings and/or objects with the shape described above
- * @param {!(VideoCaptionsTrack|VideoCaptionsTrack[])} [videoCaptions] - Captions track(s) to use for the video player for accessibility. Accepts 2 formats:
+ * @param {(VideoCaptionsTrack|VideoCaptionsTrack[])} [videoCaptions] - Captions track(s) to use for the video player for accessibility. Accepts 2 formats:
  *                                                                                      - **Object**: an object with attributes:
  *                                                                                        - src: The src URL string for the captions track file
  *                                                                                        - srcLang: The language code for the language that these captions are in (ie, 'en', 'es', 'fr')
  *                                                                                        - label: The title of the captions track
  *                                                                                        - default: Whether this track should be used by default if the user's preferences don't match an available srcLang
  *                                                                                      - **Array**: if you would like to provide multiple caption tracks, you can provide an array of objects with the shape described above
- * @param {bool}    [focused=false] - Offers a prop interface for forcing the video to start/stop without DOM events
+ * @param {boolean} [focused=false] - Offers a prop interface for forcing the video to start/stop without DOM events
  *                                      When set to true, the video will begin playing and any events that would normally stop it will be ignored
- * @param {bool}    [disableDefaultEventHandling] - Whether the video player's default mouse and touch event handling should be disabled in favor of a fully custom solution using the `focused` prop
+ * @param {boolean} [disableDefaultEventHandling] - Whether the video player's default mouse and touch event handling should be disabled in favor of a fully custom solution using the `focused` prop
  * @param {node}    [hoverTargetRef] - Ref to a custom element that should be used as the target for hover events to start/stop the video
  *                                      By default will just use the container div wrapping the player
  * @param {node}    [pausedOverlay] - Contents to render over the video while it's not playing
  * @param {node}    [loadingOverlay] - Contents to render over the video while it's loading
  * @param {number}  [loadingStateTimeout=200] - Duration in ms to wait after attempting to start the video before showing the loading overlay
  * @param {number}  [overlayTransitionDuration=400] - The transition duration in ms for how long it should take for the overlay to fade in/out
- * @param {bool}    [restartOnPaused=false] - Whether the video should reset to the beginning every time it stops playing after the user mouses out of the player
- * @param {bool}    [unloadVideoOnPaused=false] - Whether we should unload the video's sources when it is not playing in order to free up memory and bandwidth
+ * @param {boolean} [restartOnPaused=false] - Whether the video should reset to the beginning every time it stops playing after the user mouses out of the player
+ * @param {boolean} [unloadVideoOnPaused=false] - Whether we should unload the video's sources when it is not playing in order to free up memory and bandwidth
  *                                                  This can be useful in scenarios where you may have a large number of relatively large video files on a single page;
  *                                                  particularly due to a known bug in Google Chrome, if too many videos are loading in the background at the same time,
  *                                                  it starts to gum up the works so that nothing loads properly and performance can degrade significantly.
- * @param {bool}    [muted=true] - Whether the video player should be muted
- * @param {bool}    [loop=true] - Whether the video player should loop when it reaches the end
+ * @param {boolean} [muted=true] - Whether the video player should be muted
+ * @param {boolean} [loop=true] - Whether the video player should loop when it reaches the end
  * @param {string}  [preload] - Sets how much information the video element should preload before being played. Accepts one of the following values:
  *                              - **"none"**: Nothing should be preloaded before the video is played
  *                              - **"metadata"**: Only the video's metadata (ie length, dimensions) should be preloaded

--- a/src/index.js
+++ b/src/index.js
@@ -245,8 +245,10 @@ export default function HoverVideoPlayer({
           error
         );
 
-        // Revert to paused state
-        pauseVideo();
+        if (!mutableVideoState.current.isPlayerUnmounted) {
+          // If the player is still mounted, revert to a paused state
+          pauseVideo();
+        }
       })
       .finally(() => {
         // The play attempt is now complete

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,7 +35,7 @@ export function getVideoState(videoElement) {
  * Takes a videoSrc value and formats it as an array of VideoSource objects which can be used to render
  * <source> elements for the video
  *
- * @param {!(string|string[]|VideoSource|VideoSource[])}  videoSrc - Source(s) to use for the video player. Accepts 3 different formats:
+ * @param {(string|string[]|VideoSource|VideoSource[])}  videoSrc - Source(s) to use for the video player. Accepts 3 different formats:
  *                                                                   - **String**: the URL string to use as the video player's src
  *                                                                   - **Object**: an object with attributes:
  *                                                                     - src: The src URL string to use for a video player source
@@ -88,7 +88,7 @@ export function formatVideoSrc(videoSrc) {
  * @property  {string}  src - The src URL string for the captions track file
  * @property  {string}  srcLang - The language code for the language that these captions are in
  * @property  {string}  label - The title of the captions track
- * @property  {bool}    default - Whether this track should be used by default if the user's preferences don't match an available srcLang
+ * @property  {boolean} default - Whether this track should be used by default if the user's preferences don't match an available srcLang
  */
 
 /**
@@ -97,7 +97,7 @@ export function formatVideoSrc(videoSrc) {
  * Takes a videoCaptions value and formats it as an array of VideoCaptionsTrack objects which can be used to render
  * <track> elements for the video
  *
- * @param {!(string|string[]|VideoCaptionsTrack|VideoCaptionsTrack[])} videoCaptions - Captions track(s) to use for the video player for accessibility. Accepts 3 different formats:
+ * @param {(string|string[]|VideoCaptionsTrack|VideoCaptionsTrack[])} videoCaptions - Captions track(s) to use for the video player for accessibility. Accepts 3 different formats:
  *                                                                                     - **String**: the URL string to use as the captions track's src
  *                                                                                     - **Object**: an object with attributes:
  *                                                                                       - src: The src URL string for the captions track file

--- a/tests/__snapshots__/HoverVideoPlayer.test.js.snap
+++ b/tests/__snapshots__/HoverVideoPlayer.test.js.snap
@@ -252,6 +252,35 @@ exports[`Handles interaction events correctly touch events take the video throug
 </div>
 `;
 
+exports[`Prevents memory leaks when unmounted cleans everything up correctly if the video is unmounted during a failed play attempt 1`] = `
+<div>
+  <div
+    class=""
+    data-testid="hover-video-player-container"
+    style="position: relative;"
+  >
+    <div
+      class=""
+      data-testid="loading-overlay-wrapper"
+      style="position: absolute; width: 100%; height: 100%; top: 0px; bottom: 0px; left: 0px; right: 0px; z-index: 2; opacity: 0; transition: opacity 400ms;"
+    >
+      <div />
+    </div>
+    <video
+      class=""
+      data-testid="video-element"
+      loop=""
+      playsinline=""
+      style="display: block; width: 100%; object-fit: cover;"
+    >
+      <source
+        src="fake/video-file.mp4"
+      />
+    </video>
+  </div>
+</div>
+`;
+
 exports[`Prevents memory leaks when unmounted cleans everything up correctly if the video is unmounted during a pause attempt 1`] = `
 <div>
   <div

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -44,6 +44,12 @@ export function addMockedFunctionsToVideoElement(
   let isPlayAttemptInProgress = false;
 
   videoElement.load = jest.fn(() => {
+    if (isPlayAttemptInProgress) {
+      // Throw an error if load() is called while an async play() promise
+      // has not been resolved yet
+      throw new Error('Interrupted play attempt');
+    }
+
     const videoSources = videoElement.getElementsByTagName('source');
     if (videoSources.length > 0) {
       // Just assume we're using the first source


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Gyanreyer/react-hover-video-player/blob/master/CONTRIBUTING.md) doc.
- [x] I have added/updated unit tests to cover my changes.
- [x] Unit tests pass locally.
- [x] I have added appropriate documentation for my changes.
- [x] I have updated the README to reflect any changes that will affect the component's public API (if applicable).

## Problem

An error saying `Cannot read property 'pause' of null`  would be thrown if a playback attempt was rejected after the video was unmounted, as seen in #16

## Solution

Adds a check to the handling for rejected playback promises to ensure we only try to pause the video if it is still mounted.

