### PR TITLE
feat: add support for setting crossOrigin on video

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 1. **[Sources](#sources)**
     - [videoSrc](#videosrc)
     - [videoCaptions](#videocaptions)
+    - [crossOrigin](#crossorigin)
 1. **[Overlays](#overlays)**
     - [pausedOverlay](#pausedoverlay)
     - [loadingOverlay](#loadingoverlay)
@@ -164,6 +165,23 @@ In practice this looks like:
       label: 'French',
     },
   ]}
+/>
+```
+
+
+### crossOrigin
+
+**Type**: `string` | **Default**: `"anonymous"`
+
+The `crossOrigin` prop maps directly to the [HTML Video element's crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin) and allows us to define how the video element should handle CORS requests. For most purposes, you should not need to worry about setting this. The acceptable values are:
+
+- `"anonymous"`: The video element will send cross-origin requests with no credentials. This is the browser default and usually all you need for most purposes.
+- `"use-credentials"`: The video element will send cross-origin requests with credentials.
+
+```jsx
+<HoverVideoPlayer
+  videoSrc="video.mp4"
+  crossOrigin="use-credentials"
 />
 ```
 

--- a/demo/src/constants/sharedStyles.js
+++ b/demo/src/constants/sharedStyles.js
@@ -76,7 +76,7 @@ injectGlobal`
 
     /* All links to another section on the page should have an underline
         which is hidden and transitions in when hovered over */
-    &[href^="#"]:after {
+    &:after {
       content: '';
       position: absolute;
       bottom: 0;
@@ -96,7 +96,7 @@ injectGlobal`
     :hover, :focus,
     /* Links inside a paragraph should always have an underline */
     p > & {
-      :after {
+      &:after {
         left: 0;
         right: auto !important;
         width: 100% !important;

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,9 @@ import {
  *                              - **"none"**: Nothing should be preloaded before the video is played
  *                              - **"metadata"**: Only the video's metadata (ie length, dimensions) should be preloaded
  *                              - **"auto"**: The whole video file should be preloaded even if it won't be played
+ * @param {string}  [crossOrigin='anonymous'] - Sets how the video element should handle CORS requests. Accepts one of the following values:
+ *                                              - **"anonymous"**: CORS requests will have the credentials flag set to 'same-origin'
+ *                                              - **"use-credentials"**: CORS requests for this element will have the credentials flag set to 'include'
  * @param {string}  [className] - Optional className to apply custom styling to the container element
  * @param {object}  [style] - Style object to apply custom inlined styles to the hover player container
  * @param {string}  [pausedOverlayWrapperClassName] - Optional className to apply custom styling to the overlay contents' wrapper
@@ -77,6 +80,7 @@ export default function HoverVideoPlayer({
   muted = true,
   loop = true,
   preload = null,
+  crossOrigin = 'anonymous',
   className = '',
   style = null,
   pausedOverlayWrapperClassName = '',
@@ -455,6 +459,7 @@ export default function HoverVideoPlayer({
         loop={loop}
         playsInline
         preload={preload}
+        crossOrigin={crossOrigin}
         ref={videoRef}
         style={{
           ...videoSizingStyles[sizingMode],

--- a/tests/HoverVideoPlayer.test.js
+++ b/tests/HoverVideoPlayer.test.js
@@ -368,6 +368,24 @@ describe('Video props', () => {
     expect(videoElement).toHaveAttribute('loop');
   });
 
+  test('crossOrigin prop correctly sets crossorigin attribute on video', () => {
+    const { rerenderWithProps } = renderHoverVideoPlayer({
+      videoSrc: 'fake/video-file.mp4',
+      // crossOrigin is 'anonymous' by default
+    });
+
+    const videoElement = screen.getByTestId('video-element');
+
+    expect(videoElement).toHaveAttribute('crossorigin', 'anonymous');
+
+    // Re-render with looping disabled on the video
+    rerenderWithProps({
+      videoSrc: 'fake/video-file.mp4',
+      crossOrigin: 'use-credentials',
+    });
+    expect(videoElement).toHaveAttribute('crossorigin', 'use-credentials');
+  });
+
   test('preload', () => {
     const { rerenderWithProps } = renderHoverVideoPlayer({
       videoSrc: 'fake/video-file.mp4',

--- a/tests/__snapshots__/HoverVideoPlayer.test.js.snap
+++ b/tests/__snapshots__/HoverVideoPlayer.test.js.snap
@@ -23,6 +23,7 @@ exports[`Follows video interaction flows correctly an attempt to pause the video
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -59,6 +60,7 @@ exports[`Follows video interaction flows correctly an attempt to play the video 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -95,6 +97,7 @@ exports[`Follows video interaction flows correctly an attempt to play the video 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -131,6 +134,7 @@ exports[`Follows video interaction flows correctly an attempt to play the video 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -167,6 +171,7 @@ exports[`Follows video interaction flows correctly the video will be paused imme
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -203,6 +208,7 @@ exports[`Handles interaction events correctly mouseEnter and mouseLeave events t
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -239,6 +245,7 @@ exports[`Handles interaction events correctly touch events take the video throug
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -268,6 +275,7 @@ exports[`Prevents memory leaks when unmounted cleans everything up correctly if 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -297,6 +305,7 @@ exports[`Prevents memory leaks when unmounted cleans everything up correctly if 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -326,6 +335,7 @@ exports[`Prevents memory leaks when unmounted cleans everything up correctly if 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -362,6 +372,7 @@ exports[`Supports browsers that do not return a promise from video.play() handle
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -384,6 +395,7 @@ exports[`Supports browsers that do not return a promise from video.play() handle
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -406,6 +418,7 @@ exports[`Video playback errors handles a video playback error correectly 1`] = `
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -428,6 +441,30 @@ exports[`Video playback errors handles playback errors correctly for browsers th
   >
     <video
       class=""
+      crossorigin="anonymous"
+      data-testid="video-element"
+      loop=""
+      playsinline=""
+      style="display: block; width: 100%; object-fit: cover;"
+    >
+      <source
+        src="fake/video-file.mp4"
+      />
+    </video>
+  </div>
+</div>
+`;
+
+exports[`Video props crossOrigin prop correctly sets crossorigin attribute on video 1`] = `
+<div>
+  <div
+    class=""
+    data-testid="hover-video-player-container"
+    style="position: relative;"
+  >
+    <video
+      class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -450,6 +487,7 @@ exports[`Video props loop prop correctly sets loop attribute on video 1`] = `
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -472,6 +510,7 @@ exports[`Video props muted prop correctly sets muted attribute on video 1`] = `
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -494,6 +533,7 @@ exports[`Video props preload 1`] = `
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -516,6 +556,7 @@ exports[`disableDefaultEventHandling disableDefaultEventHandling prop disables a
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -538,6 +579,7 @@ exports[`focused focused prop starts and stops the video correctly 1`] = `
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -560,6 +602,7 @@ exports[`focused other events which would normally stop the video are ignored if
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -582,6 +625,7 @@ exports[`overlayTransitionDuration Stop attempts stop immediately if a pausedOve
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -611,6 +655,7 @@ exports[`overlayTransitionDuration Stop attempts take the amount of time set by 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -647,6 +692,7 @@ exports[`pausedOverlay and loadingOverlay pausedOverlay and loadingOverlay are s
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -676,6 +722,7 @@ exports[`pausedOverlay and loadingOverlay the loading state overlay is not shown
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -698,6 +745,7 @@ exports[`restartOnPaused restartOnPaused prop does not restart the video when se
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -720,6 +768,7 @@ exports[`restartOnPaused restartOnPaused prop restarts the video when set to tru
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -749,6 +798,7 @@ exports[`sizingMode sizingMode "container" sets correct styling on the player 1`
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -778,6 +828,7 @@ exports[`sizingMode sizingMode "manual" sets correct styling on the player 1`] =
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -807,6 +858,7 @@ exports[`sizingMode sizingMode "overlay" sets correct styling on the player 1`] 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -836,6 +888,7 @@ exports[`sizingMode sizingMode "video" sets correct styling on the player 1`] = 
     </div>
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -858,6 +911,7 @@ exports[`unloadVideoOnPaused unloadVideoOnPaused prop unloads the video's source
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -876,6 +930,7 @@ exports[`videoCaptions prop Handles invalid videoCaptions prop values correctly 
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -898,6 +953,7 @@ exports[`videoCaptions prop Handles invalid videoCaptions prop values correctly 
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -932,6 +988,7 @@ exports[`videoCaptions prop Handles valid videoCaptions prop values correctly co
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -960,6 +1017,7 @@ exports[`videoCaptions prop Handles valid videoCaptions prop values correctly co
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1000,6 +1058,7 @@ exports[`videoSrc prop Handles invalid videoSrc prop values correctly correctly 
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1018,6 +1077,7 @@ exports[`videoSrc prop Handles invalid videoSrc prop values correctly correctly 
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1036,6 +1096,7 @@ exports[`videoSrc prop Handles invalid videoSrc prop values correctly correctly 
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1062,6 +1123,7 @@ exports[`videoSrc prop Handles valid videoSrc prop values correctly correctly ha
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1084,6 +1146,7 @@ exports[`videoSrc prop Handles valid videoSrc prop values correctly correctly ha
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1107,6 +1170,7 @@ exports[`videoSrc prop Handles valid videoSrc prop values correctly correctly ha
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1134,6 +1198,7 @@ exports[`videoSrc prop Handles valid videoSrc prop values correctly correctly ha
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""
@@ -1159,6 +1224,7 @@ exports[`videoSrc prop Handles valid videoSrc prop values correctly correctly ha
   >
     <video
       class=""
+      crossorigin="anonymous"
       data-testid="video-element"
       loop=""
       playsinline=""


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Gyanreyer/react-hover-video-player/blob/master/CONTRIBUTING.md) doc.
- [x] I have added/updated unit tests to cover my changes.
- [x] Unit tests pass locally.
- [x] I have added appropriate documentation for my changes.
- [x] I have updated the README to reflect any changes that will affect the component's public API (if applicable).

## Problem

At Waymark, we recently ran into a bug in Chrome where the same video file was being loaded in multiple different video elements throughout the editor, some with CORS headers and some without, and depending on which got loaded and cached first, this could cause CORS errors.

## Solution

This exposes the ability to set `crossOrigin` on the component's video element in the API and explicitly sets `crossOrigin='anonymous'` on the video by default.
