### PR TITLE
fix: switch main file from es modules build to commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-hover-video-player",
   "version": "0.0.0-development",
   "description": "React component which manages playing a video when the user hovers over it and pausing when they stop.",
-  "main": "es/index.js",
+  "main": "lib/index.js",
   "files": [
     "es",
     "lib"


### PR DESCRIPTION
## Problem

The `main` entrypoint file for this package was set to use the ES modules build at `es/index.js` but this can cause compilation issues for some build systems and generally cause a lot of unnecessary hassle.

## Solution

Changing the `main` file to the CommonJS build at `lib/index.js` should fix this, ideally without breaking anything.

Ideally this switch should not break anything, but since various build systems may interact with this in unexpected ways I am marking this as a breaking change out of an abundance of caution.