### PR TITLE
docs: fix documentation site showing 404 error

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,19 +18,20 @@
 <body>
   <div id="app"></div>
   <script>
-    var homepage;
+    var basePath;
 
     if (window.location.host.startsWith('localhost')) {
       // If we're testing locally, use the local README file
-      homepage = 'README.md';
+      basePath = '/';
     } else {
       // If we're not in a local environment, load the README from the github repo
-      homepage = 'https://github.com/Gyanreyer/react-hover-video-player/blob/main/README.md?raw=true';
+      basePath = 'https://raw.githubusercontent.com/Gyanreyer/react-hover-video-player/main/';
     }
 
     window.$docsify = {
-      repo: 'https://github.com/Gyanreyer/react-hover-video-player.git',
-      homepage: homepage,
+      repo: 'https://github.com/Gyanreyer/react-hover-video-player',
+      homepage: 'README.md',
+      basePath: basePath,
     }
   </script>
   <script src="vendor/docsify.js"></script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,5 +10,9 @@ gulp.task('copy-docs-readme', () =>
 // Watches the README file and copies it into the docs/ directory every time it is changed
 // Run with `npx gulp watch-docs`
 gulp.task('watch-docs', () => {
-  gulp.watch(['README.md'], gulp.series('copy-docs-readme'));
+  const copyDocsReadmeTask = gulp.series('copy-docs-readme');
+  // Run the task once initially
+  copyDocsReadmeTask();
+  // Re-run the task every time the README.md file changes
+  gulp.watch('README.md', copyDocsReadmeTask);
 });


### PR DESCRIPTION
- Fix documentation site so it can actually load the github repo's README in production as intended
- Fix `watch-docs` gulp task to make sure it runs once initially