### PR TITLE
fix: fix unloadVideoOnPaused not always unloading after a play promise resolves

### DIFF
--- a/tests/cypress/component/interactionFlows.spec.js
+++ b/tests/cypress/component/interactionFlows.spec.js
@@ -419,11 +419,9 @@ describe('Handles interactions correctly', () => {
   });
 
   it('the video can be played and paused through the focused prop', () => {
-    const videoSrc = makeMockVideoSrc();
-
     mount(
       <HoverVideoPlayerWrappedWithFocusToggleButton
-        videoSrc={videoSrc}
+        videoSrc={makeMockVideoSrc()}
         disableDefaultEventHandling
       />
     );


### PR DESCRIPTION
### The Problem

I recently observed that if the user stops hovering while the video is still loading and `unloadVideoOnPaused` is true, the video will get stuck so it never get properly unloaded even after the play promise resolves.

This performs a little refactoring of how we determine whether the video is currently "active" or not, and feels much more stable and consistent now.