### PR TITLE
feat: add new hoverOverlay prop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -268,6 +268,32 @@ After the user stops hovering on the player, the video will continue playing unt
 />
 ```
 
+### hoverOverlay
+
+**Type**: `node` | **Default**: `null`
+
+`hoverOverlay` is an optional prop that accepts any renderable content that you would like to be displayed over the video while the player is active from a hover/touch event or when the [focused](#focused) prop is `true`.
+
+This can be useful if you wish to reveal content to the user when they hover while the video still plays underneath it.
+
+Note that this overlay takes highest ordering priority and will be displayed on top of both the [pausedOverlay](#pausedoverlay) and [loadingOverlay](#loadingoverlay) if they are set.
+
+```jsx
+<HoverVideoPlayer
+  videoSrc="video.mp4"
+  hoverOverlay={
+    <div className="hover-overlay">
+      <h1>Video Title</h1>
+      <p>
+        Here is a short description of the video.
+        You can still see the video playing underneath this overlay.
+        <a href="/video-page">Click here to read more</a>
+      </p>
+    </div>
+  }
+/>
+```
+
 ## Custom Event Handling
 
 ### hoverTarget
@@ -496,7 +522,7 @@ The base styling for this component's contents are set using inline styling. You
     width: '50%',
   }}
 
-  /* ~~~ PAUSEED OVERLAY WRAPPER DIV ~~~ */
+  /* ~~~ PAUSED OVERLAY WRAPPER DIV ~~~ */
   // Applies a custom class to the div wrapping the pausedOverlay contents
   pausedOverlayWrapperClassName="paused-overlay-wrapper"
   // Applies inline styles to the div wrapping the pausedOverlay contents
@@ -510,6 +536,15 @@ The base styling for this component's contents are set using inline styling. You
   // Applies inline styles to the div wrapping the loadingOverlay contents
   loadingOverlayWrapperStyle={{
     backgroundColor: 'rgba(0, 0, 0, 0.1)',
+  }}
+
+  /* ~~~ HOVER OVERLAY WRAPPER DIV ~~~ */
+  // Applies a custom class to the div wrapping the hoverOverlay contents
+  hoverOverlayWrapperClassName="hover-overlay-wrapper"
+  // Applies inline styles to the div wrapping the hoverOverlay contents
+  hoverOverlayWrapperStyle={{
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    color: "white",
   }}
 
   /* ~~~ VIDEO ELEMENT ~~~ */

--- a/src/HoverVideoPlayer.types.ts
+++ b/src/HoverVideoPlayer.types.ts
@@ -85,6 +85,11 @@ export interface HoverVideoPlayerProps {
    */
   hoverTarget?: HoverTarget;
   /**
+   * Contents to render over the video while the user is hovering over the player.
+   * @defaultValue null
+   */
+  hoverOverlay?: JSX.Element;
+  /**
    * Contents to render over the video while it's not playing.
    * @defaultValue null
    */
@@ -203,6 +208,16 @@ export interface HoverVideoPlayerProps {
    * @defaultValue null
    */
   style?: React.CSSProperties;
+  /**
+   * Optional className to apply custom styling to the div element wrapping the `hoverOverlay` contents.
+   * @defaultValue null
+   */
+  hoverOverlayWrapperClassName?: string;
+  /**
+   * Style object to apply custom inlined styles to the div element wrapping the `hoverOverlay` contents.
+   * @defaultValue null
+   */
+  hoverOverlayWrapperStyle?: React.CSSProperties;
   /**
    * Optional className to apply custom styling to the div element wrapping the `pausedOverlay` contents.
    * @defaultValue null

--- a/src/component/HoverVideoPlayer.tsx
+++ b/src/component/HoverVideoPlayer.tsx
@@ -28,6 +28,7 @@ const HoverVideoPlayer = ({
   focused = false,
   disableDefaultEventHandling = false,
   hoverTarget = null,
+  hoverOverlay = null,
   pausedOverlay = null,
   loadingOverlay = null,
   loadingStateTimeout = 200,
@@ -47,6 +48,8 @@ const HoverVideoPlayer = ({
   disablePictureInPicture = true,
   className = null,
   style = null,
+  hoverOverlayWrapperClassName = null,
+  hoverOverlayWrapperStyle = null,
   pausedOverlayWrapperClassName = null,
   pausedOverlayWrapperStyle = null,
   loadingOverlayWrapperClassName = null,
@@ -82,6 +85,14 @@ const HoverVideoPlayer = ({
   const shouldPlayVideo = isHoveringOverVideo || focused;
 
   const hasPausedOverlay = Boolean(pausedOverlay);
+  const hasHoverOverlay = Boolean(hoverOverlay);
+
+  // If we have a paused or hover overlay, the player should wait
+  // for the overlay(s) to finish transitioning back in before we
+  // pause the video
+  const shouldWaitForOverlayTransitionBeforePausing =
+    hasPausedOverlay || hasHoverOverlay;
+
   const hasLoadingOverlay = Boolean(loadingOverlay);
 
   // Effect handles transitioning the video between playing or paused states
@@ -93,7 +104,7 @@ const HoverVideoPlayer = ({
     playbackRangeEnd,
     loop,
     restartOnPaused,
-    hasPausedOverlay,
+    shouldWaitForOverlayTransitionBeforePausing,
     hasLoadingOverlay,
     overlayTransitionDuration,
     loadingStateTimeout
@@ -166,6 +177,24 @@ const HoverVideoPlayer = ({
           data-testid="loading-overlay-wrapper"
         >
           {loadingOverlay}
+        </div>
+      ) : null}
+      {hasHoverOverlay ? (
+        <div
+          style={{
+            ...expandToFillContainerStyle,
+            zIndex: 3,
+            // Show the hover overlay when the player is hovered/playing
+            opacity: shouldPlayVideo ? 1 : 0,
+            transition: `opacity ${overlayTransitionDuration}ms`,
+            // Disable pointer events on the hover overlay when it's hidden
+            pointerEvents: shouldPlayVideo ? 'auto' : 'none',
+            ...hoverOverlayWrapperStyle,
+          }}
+          className={hoverOverlayWrapperClassName}
+          data-testid="hover-overlay-wrapper"
+        >
+          {hoverOverlay}
         </div>
       ) : null}
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}

--- a/tests/cypress/component/hoverOverlay.spec.js
+++ b/tests/cypress/component/hoverOverlay.spec.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+import HoverVideoPlayer from '../../../src';
+
+import {
+  HoverOverlay,
+  HoverVideoPlayerWrappedWithFocusToggleButton,
+  makeMockVideoSrc,
+} from '../utils';
+import { hoverOverlayWrapperSelector } from '../constants';
+
+describe('hoverOverlay is applied correctly', () => {
+  it('Shows the hoverOverlay when the video is played via a hover interaction', () => {
+    mount(
+      <HoverVideoPlayer
+        videoSrc={makeMockVideoSrc({ throttleKbps: 1000 })}
+        hoverOverlay={<HoverOverlay />}
+        overlayTransitionDuration={100}
+      />
+    );
+
+    cy.checkOverlayVisibilty({ hover: false });
+
+    // Hover to start playing the video
+    cy.triggerEventOnPlayer('mouseenter');
+
+    // The overlay should have faded in before the video starts playing
+    cy.checkOverlayVisibilty({ hover: true });
+    cy.checkVideoPlaybackState('loading');
+
+    // The overlay should remain visible as the video is playing
+    cy.checkVideoPlaybackState('playing');
+    cy.checkOverlayVisibilty({ hover: true });
+
+    // Mouse out to stop the video
+    cy.triggerEventOnPlayer('mouseleave');
+    // The hover overlay should be hidden again
+    cy.checkOverlayVisibilty({ hover: false });
+
+    cy.checkVideoPlaybackState('paused');
+  });
+
+  it('Shows the hoverOverlay when the video is played via the focused prop', () => {
+    mount(
+      <HoverVideoPlayerWrappedWithFocusToggleButton
+        videoSrc={makeMockVideoSrc({ throttleKbps: 1000 })}
+        hoverOverlay={<HoverOverlay />}
+        overlayTransitionDuration={100}
+      />
+    );
+
+    cy.checkOverlayVisibilty({ hover: false });
+
+    // Toggle the focused prop to true to start the video
+    cy.get('[data-testid="toggle-focus-button"]').click();
+
+    // The overlay should have faded in before the video starts playing
+    cy.checkOverlayVisibilty({ hover: true });
+    cy.checkVideoPlaybackState('loading');
+
+    // The overlay should remain visible as the video is playing
+    cy.checkVideoPlaybackState('playing');
+    cy.checkOverlayVisibilty({ hover: true });
+
+    // Toggle the focused prop back to false to stop the video
+    cy.get('[data-testid="toggle-focus-button"]').click();
+    cy.checkOverlayVisibilty({ hover: false });
+
+    cy.checkVideoPlaybackState('paused');
+  });
+
+  it('Applies custom style props to hoverOverlay wrapper', () => {
+    mount(
+      <HoverVideoPlayer
+        videoSrc={makeMockVideoSrc()}
+        hoverOverlay={<HoverOverlay />}
+        hoverOverlayWrapperClassName="custom-hover-overlay-classname"
+        hoverOverlayWrapperStyle={{
+          backgroundColor: 'blue',
+        }}
+      />
+    );
+
+    cy.checkOverlayVisibilty({ hover: false });
+
+    cy.get(hoverOverlayWrapperSelector).should(
+      'have.css',
+      'background-color',
+      'rgb(0, 0, 255)'
+    );
+    cy.get(hoverOverlayWrapperSelector).should(
+      'have.class',
+      'custom-hover-overlay-classname'
+    );
+  });
+});

--- a/tests/cypress/component/sizingMode.spec.js
+++ b/tests/cypress/component/sizingMode.spec.js
@@ -7,6 +7,7 @@ import {
   videoElementSelector,
   pausedOverlayWrapperSelector,
   loadingOverlayWrapperSelector,
+  hoverOverlayWrapperSelector,
   playerContainerSelector,
 } from '../constants';
 
@@ -42,6 +43,18 @@ describe('sizingMode prop', () => {
             data-testid="loading-overlay"
           >
             LOADING
+          </div>
+        }
+        hoverOverlay={
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'rgba(0, 255, 255, 0.7)',
+            }}
+            data-testid="hover-overlay"
+          >
+            HOVER
           </div>
         }
       />
@@ -91,17 +104,6 @@ describe('sizingMode prop', () => {
     });
 
     // The loading overlay should be sized to match the paused overlay's dimensions
-    cy.get(loadingOverlayWrapperSelector).should(([loadingOverlayWrapper]) => {
-      expect(loadingOverlayWrapper).to.have.css('width', '200px');
-
-      const loadingOverlayWrapperHeight = parseFloat(
-        window.getComputedStyle(loadingOverlayWrapper).height
-      );
-      expect(loadingOverlayWrapperHeight).to.be.closeTo(
-        videoElementHeight,
-        0.001
-      );
-    });
     cy.get('[data-testid="loading-overlay"]').should(([loadingOverlay]) => {
       expect(loadingOverlay).to.have.css('width', '200px');
 
@@ -109,6 +111,15 @@ describe('sizingMode prop', () => {
         window.getComputedStyle(loadingOverlay).height
       );
       expect(loadingOverlayHeight).to.be.closeTo(videoElementHeight, 0.001);
+    });
+    // The hover overlay should be sized to match the paused overlay's dimensions
+    cy.get('[data-testid="hover-overlay"]').should(([hoverOverlay]) => {
+      expect(hoverOverlay).to.have.css('width', '200px');
+
+      const hoverOverlayHeight = parseFloat(
+        window.getComputedStyle(hoverOverlay).height
+      );
+      expect(hoverOverlayHeight).to.be.closeTo(videoElementHeight, 0.001);
     });
   });
 
@@ -141,6 +152,18 @@ describe('sizingMode prop', () => {
             LOADING
           </div>
         }
+        hoverOverlay={
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'rgba(0, 255, 255, 0.7)',
+            }}
+            data-testid="hover-overlay"
+          >
+            HOVER
+          </div>
+        }
       />
     );
 
@@ -167,6 +190,14 @@ describe('sizingMode prop', () => {
       .should('have.css', 'width', '300px')
       .should('have.css', 'height', '100px');
     cy.get('[data-testid="loading-overlay"]')
+      .should('have.css', 'width', '300px')
+      .should('have.css', 'height', '100px');
+
+    // The hover overlay should be sized to match the paused overlay's dimensions
+    cy.get(hoverOverlayWrapperSelector)
+      .should('have.css', 'width', '300px')
+      .should('have.css', 'height', '100px');
+    cy.get('[data-testid="hover-overlay"]')
       .should('have.css', 'width', '300px')
       .should('have.css', 'height', '100px');
   });
@@ -204,6 +235,18 @@ describe('sizingMode prop', () => {
             LOADING
           </div>
         }
+        hoverOverlay={
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              backgroundColor: 'rgba(0, 255, 255, 0.7)',
+            }}
+            data-testid="hover-overlay"
+          >
+            HOVER
+          </div>
+        }
       />
     );
 
@@ -229,8 +272,15 @@ describe('sizingMode prop', () => {
     cy.get(loadingOverlayWrapperSelector)
       .should('have.css', 'width', '100px')
       .should('have.css', 'height', '200px');
-
     cy.get('[data-testid="loading-overlay"]')
+      .should('have.css', 'width', '100px')
+      .should('have.css', 'height', '200px');
+
+    // The hover overlay should be sized to match the container's dimensions
+    cy.get(hoverOverlayWrapperSelector)
+      .should('have.css', 'width', '100px')
+      .should('have.css', 'height', '200px');
+    cy.get('[data-testid="hover-overlay"]')
       .should('have.css', 'width', '100px')
       .should('have.css', 'height', '200px');
   });

--- a/tests/cypress/constants.ts
+++ b/tests/cypress/constants.ts
@@ -3,5 +3,7 @@ export const pausedOverlayWrapperSelector =
   '[data-testid="paused-overlay-wrapper"]';
 export const loadingOverlayWrapperSelector =
   '[data-testid="loading-overlay-wrapper"]';
+export const hoverOverlayWrapperSelector =
+  '[data-testid="hover-overlay-wrapper"]';
 export const playerContainerSelector =
   '[data-testid="hover-video-player-container"]';

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -2,6 +2,7 @@ import {
   videoElementSelector,
   pausedOverlayWrapperSelector,
   loadingOverlayWrapperSelector,
+  hoverOverlayWrapperSelector,
   playerContainerSelector,
 } from '../constants';
 
@@ -9,40 +10,42 @@ Cypress.Commands.add('triggerEventOnPlayer', (event) =>
   cy.get(playerContainerSelector).trigger(event)
 );
 
-Cypress.Commands.add('checkOverlayVisibilty', ({ paused, loading }) => {
-  cy.get(playerContainerSelector)
-    .children(pausedOverlayWrapperSelector)
-    .should(([pausedOverlay]) => {
-      if (paused === undefined) {
-        assert.notExists(
-          pausedOverlay,
-          'There should not be a loading overlay'
-        );
-      } else {
-        assert.strictEqual(
-          pausedOverlay.style.opacity,
-          paused ? '1' : '0',
-          `The paused overlay should be ${paused ? 'visible' : 'hidden'}`
-        );
-      }
-    });
+Cypress.Commands.add('checkOverlayVisibilty', ({ paused, loading, hover }) => {
+  if (paused === undefined) {
+    cy.log('There should not be a paused overlay');
+    cy.get(pausedOverlayWrapperSelector).should('not.exist');
+  } else {
+    cy.log(`The paused overlay should be ${paused ? 'visible' : 'hidden'}`);
+    cy.get(pausedOverlayWrapperSelector).should(
+      'have.css',
+      'opacity',
+      paused ? '1' : '0'
+    );
+  }
 
-  cy.get(playerContainerSelector)
-    .children(loadingOverlayWrapperSelector)
-    .should(([loadingOverlay]) => {
-      if (loading === undefined) {
-        assert.notExists(
-          loadingOverlay,
-          'There should not be a loading overlay'
-        );
-      } else {
-        assert.strictEqual(
-          loadingOverlay.style.opacity,
-          loading ? '1' : '0',
-          `The loading overlay should be ${loading ? 'visible' : 'hidden'}`
-        );
-      }
-    });
+  if (loading === undefined) {
+    cy.log('There should not be a loading overlay');
+    cy.get(loadingOverlayWrapperSelector).should('not.exist');
+  } else {
+    cy.log(`The loading overlay should be ${loading ? 'visible' : 'hidden'}`);
+    cy.get(loadingOverlayWrapperSelector).should(
+      'have.css',
+      'opacity',
+      loading ? '1' : '0'
+    );
+  }
+
+  if (hover === undefined) {
+    cy.log('There should not be a hover overlay');
+    cy.get(hoverOverlayWrapperSelector).should('not.exist');
+  } else {
+    cy.log(`The hover overlay should be ${hover ? 'visible' : 'hidden'}`);
+    cy.get(hoverOverlayWrapperSelector).should(
+      'have.css',
+      'opacity',
+      hover ? '1' : '0'
+    );
+  }
 });
 
 Cypress.Commands.add(

--- a/tests/cypress/utils.tsx
+++ b/tests/cypress/utils.tsx
@@ -71,13 +71,27 @@ export function LoadingOverlay(): JSX.Element {
   return (
     <div
       style={{
-        display: 'block',
         width: '100%',
         height: '100%',
         backgroundColor: 'yellow',
       }}
     >
       LOADING
+    </div>
+  );
+}
+
+export function HoverOverlay(): JSX.Element {
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'rgba(0, 180, 180, 0.7)',
+        color: 'white',
+      }}
+    >
+      HOVERING
     </div>
   );
 }


### PR DESCRIPTION
- Adds new `hoverOverlay` prop
  - This prop accepts optional contents to render over the player while the user is hovering over it

Resolves #54 