### PR TITLE
Make looping within a playback range smoother

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,10 @@
             {
               "type": "refactor",
               "release": "minor"
+            },
+            {
+              "type": "perf",
+              "release": "minor"
             }
           ],
           "parserOpts": {


### PR DESCRIPTION
The logic for making a video loop within a playback range was initially based on watching the `timeupdate` event on the video element, but this event is not extremely reliable in terms of how frequently it will be called; we can get a much smoother/snappier experience by instead using an update loop with `requestAnimationFrame` to check the video's current time each frame.