### PR TITLE
refactor: update playback range checks to use timeupdate event

### DIFF
--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -10,7 +10,7 @@
   "video": false,
   "screenshotOnRunFailure": false,
   "retries": {
-    "runMode": 2,
+    "runMode": 4,
     "openMode": 0
   }
 }


### PR DESCRIPTION
The check for keeping the video inside of its playback range was being run on a `requestAnimationFrame` event loop, but some experimentation revealed that this didn't actually provide a much smoother/snappier user experience compared to a simple `timeupdate` event listener.