### PR TITLE
feat(hovervideoplayer): enable passing through generic attributes to the container div

### DIFF
--- a/src/HoverVideoPlayer.types.ts
+++ b/src/HoverVideoPlayer.types.ts
@@ -54,7 +54,8 @@ export type VideoCaptionsProp = VideoCaptionsTrack | VideoCaptionsTrack[];
  */
 export type HoverTarget = Node | (() => Node) | React.RefObject<Node>;
 
-export interface HoverVideoPlayerProps {
+export interface HoverVideoPlayerProps
+  extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Source(s) to load from and play in the video player.
    */
@@ -217,11 +218,6 @@ export interface HoverVideoPlayerProps {
    * @defaultValue true
    */
   disablePictureInPicture?: boolean;
-  /**
-   * Optional className to apply custom styling to the component's container div element.
-   * @defaultValue null
-   */
-  className?: string;
   /**
    * Style object to apply custom inlined styles to the component's container div element.
    * @defaultValue null

--- a/src/component/HoverVideoPlayer.tsx
+++ b/src/component/HoverVideoPlayer.tsx
@@ -52,7 +52,6 @@ export default function HoverVideoPlayer({
   controlsList = null,
   disableRemotePlayback = true,
   disablePictureInPicture = true,
-  className = null,
   style = null,
   hoverOverlayWrapperClassName = null,
   hoverOverlayWrapperStyle = null,
@@ -66,6 +65,7 @@ export default function HoverVideoPlayer({
   videoStyle = null,
   sizingMode = 'video',
   shouldSuppressPlaybackInterruptedErrors = true,
+  ...spreadableProps
 }: HoverVideoPlayerProps): JSX.Element {
   // Element refs
   const containerRef = useRef(null);
@@ -326,12 +326,12 @@ export default function HoverVideoPlayer({
     <div
       data-testid="hover-video-player-container"
       ref={containerRef}
-      className={className}
       style={{
         ...containerSizingStyles[sizingMode],
         position: 'relative',
         ...style,
       }}
+      {...spreadableProps}
     >
       {hasPausedOverlay ? (
         <div

--- a/tests/cypress/component/spreadableProps.spec.tsx
+++ b/tests/cypress/component/spreadableProps.spec.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+import HoverVideoPlayer from 'react-hover-video-player';
+
+import { makeMockVideoSrc } from '../utils';
+import { playerContainerSelector } from '../constants';
+
+describe('Generic html attributes can be passed through tp the container div', () => {
+  it('sets custom data-testid and id attributes on the container element', () => {
+    mount(
+      <HoverVideoPlayer
+        videoSrc={makeMockVideoSrc()}
+        data-testid="custom-data-testid"
+        id="video-player-id"
+      />
+    );
+
+    // The default container selector's data-testid should have been overridden
+    cy.get(playerContainerSelector).should('not.exist');
+
+    cy.get('[data-testid="custom-data-testid"]')
+      .should('exist')
+      .should('have.attr', 'id', 'video-player-id');
+  });
+});


### PR DESCRIPTION
Generic attributes/props can now be passed through to the component's container div. This resolves #81 where they wanted to be able to set their own custom `data-testid` attribute on the component.