### PR TITLE
[Fix] Missing declaration file for module in ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     "require": "./dist/index.cjs",
-    "import": "./dist/index.mjs"
+    "import": "./dist/index.mjs",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/Gyanreyer/react-hover-video-player/blob/main/CONTRIBUTING.md) doc.
- [ ] I have added/updated unit tests to cover my changes.
- [X] Unit tests pass locally.
- [ ] I have added appropriate documentation for my changes.
- [ ] I have updated the README to reflect any changes that will affect the component's public API (if applicable).

## Problem

When using the library in a Typescript project, I got the following error:

```
Could not find a declaration file for module 'react-hover-video-player'. '/Users/<path>/node_modules/react-hover-video-player/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/Users/<path>/node_modules/react-hover-video-player/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'react-hover-video-player' library may need to update its package.json or typings.ts(7016)
```

So I looked into the library locally, and adding the export inside the package.json made the error go away.

## Solution

Export types in package.json

